### PR TITLE
fix: Automerge job can not merge PRs due to GitHub API changed #2

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: ridedott/merge-me-action@v2
         with:
           GITHUB_LOGIN: nsmbot
+          ENABLED_FOR_MANUAL_CHANGES: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   update-dependent-repositories:
     continue-on-error: true


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

Related to https://github.com/networkservicemesh/integration-tests/pull/290