### PR TITLE
[qfix] Fix automerge version to master

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           find . -type f ! -name 'suite.go' ! -name '*.gen.go' ! -name 'go.sum' ! -name 'go.mod' -exec git diff --exit-code origin/main -- {} +
       - name: Merge PR
-        uses: ridedott/merge-me-action@v2
+        uses: ridedott/merge-me-action@master
         with:
           GITHUB_LOGIN: nsmbot
           ENABLED_FOR_MANUAL_CHANGES: true


### PR DESCRIPTION
Updates used `ridedott/merge-me-action` to `master`.