### PR TITLE
[qfix] Remove timestamps from logs

### DIFF
--- a/extensions/logs/logs.go
+++ b/extensions/logs/logs.go
@@ -117,8 +117,7 @@ func captureLogs(from time.Time, dir string) {
 		wg.Add(1)
 		captureLogsTask := func() {
 			opts := &corev1.PodLogOptions{
-				Timestamps: true,
-				SinceTime:  &metav1.Time{Time: from},
+				SinceTime: &metav1.Time{Time: from},
 			}
 			savePodLogs(operationCtx, pod, opts, false, dir)
 			savePodLogs(operationCtx, pod, opts, true, dir)


### PR DESCRIPTION
## Description
Removes k8s timestamps from logs.

## Motivation
We have timestamps in all application logs coming from logrus, we don't need additional k8s timestamps.