### PR TITLE
fix: Rework prefetch image searching logic

### DIFF
--- a/extensions/base/suite.go
+++ b/extensions/base/suite.go
@@ -18,6 +18,8 @@
 package base
 
 import (
+	"fmt"
+
 	"github.com/networkservicemesh/gotestmd/pkg/suites/shell"
 	"github.com/networkservicemesh/integration-tests/extensions/checkout"
 	"github.com/networkservicemesh/integration-tests/extensions/logs"
@@ -54,7 +56,7 @@ const (
 
 // SetupSuite runs all extensions
 func (s *Suite) SetupSuite() {
-	s.checkout.Repository = "networkservicemesh/deployments-k8s"
+	repo := "networkservicemesh/deployments-k8s"
 	s.checkout.Version = sha[:8]
 	s.checkout.Dir = "../" // Note: this should be synced with input parameters in gen.go file
 
@@ -62,7 +64,14 @@ func (s *Suite) SetupSuite() {
 	s.checkout.SetupSuite()
 
 	// prefetch
-	s.prefetch.Dir = "../deployments-k8s" // Note: this should be synced with input parameters in gen.go file
+	s.prefetch.SourcesURLs = []string{
+		// Note: use urls for local image files.
+		// For example:
+		//    "file://my-debug-images-for-prefetch.yaml"
+		//    "file://deployments-k8s/apps/"
+		fmt.Sprintf("https://raw.githubusercontent.com/%v/%v/external-images.yaml", repo, sha),
+		fmt.Sprintf("https://api.github.com/repos/%v/contents/apps?ref=%v", repo, sha),
+	}
 
 	s.prefetch.SetT(s.T())
 	s.prefetch.SetupSuite()

--- a/extensions/prefetch/images/images.go
+++ b/extensions/prefetch/images/images.go
@@ -1,3 +1,20 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package images provides helpful utilities for searching images for prefetching.
 package images
 
 import (
@@ -18,6 +35,11 @@ type ImageList struct {
 	Images []string
 }
 
+// ReteriveList gets list of all images from the source.
+// sources can be in format
+// 1. Local files: file://..
+// 2. Remote gettable content: https://raw.githubusercontent.com/...
+// 3. Remote files and dirs via github api: https://api.github.com/repos/...
 func ReteriveList(sources []string, match func(string) bool) *ImageList {
 	var result = new(ImageList)
 	var filesURls []string

--- a/extensions/prefetch/images/images.go
+++ b/extensions/prefetch/images/images.go
@@ -1,0 +1,182 @@
+package images
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ImageList struct {
+	Images []string
+}
+
+func ReteriveList(sources []string, match func(string) bool) *ImageList {
+	var result = new(ImageList)
+	var filesURls []string
+
+	for _, source := range sources {
+		filesURls = append(filesURls, reteriveFileList(source, match)...)
+	}
+
+	for _, fileURL := range filesURls {
+		var content = readContent(fileURL)
+		var images = getImages(content)
+		result.Images = append(result.Images, images...)
+	}
+
+	return result
+}
+
+func getImages(content []byte) []string {
+	var imagesList ImageList
+
+	_ = yaml.Unmarshal(content, &imagesList)
+
+	if len(imagesList.Images) > 0 {
+		return imagesList.Images
+	}
+
+	var imagePattern = regexp.MustCompile(".*image: (?P<image>.*)")
+	var imageSubexpIndex = imagePattern.SubexpIndex("image")
+	var result []string
+
+	if imagePattern.Match(content) {
+		for _, match := range imagePattern.FindAllStringSubmatch(string(content), -1) {
+			result = append(result, match[imageSubexpIndex])
+		}
+	}
+	return result
+}
+
+func readContent(rawurl string) []byte {
+	var u, _ = url.Parse(rawurl)
+	if u.Scheme == "file" {
+		var p = filepath.Join(u.Hostname(), u.Path)
+		b, err := ioutil.ReadFile(p)
+		if err == nil {
+			return b
+		}
+		return nil
+	}
+	if u.Scheme == "http" || u.Scheme == "https" {
+		resp, err := http.Get(rawurl)
+		if err != nil {
+			return nil
+		}
+		defer resp.Body.Close()
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil
+		}
+		return b
+	}
+
+	return nil
+}
+
+func reteriveLocalFileList(rawurl string, match func(string) bool) []string {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil
+	}
+
+	basePath := filepath.Join(u.Hostname(), u.Path)
+
+	root, err := os.Open(basePath)
+	if err != nil {
+		return nil
+	}
+
+	stat, err := root.Stat()
+	if err != nil {
+		return nil
+	}
+
+	if !stat.IsDir() {
+		return []string{fmt.Sprintf("file://%v", basePath)}
+	}
+
+	var result []string
+
+	files, err := ioutil.ReadDir(basePath)
+	if err != nil {
+		return nil
+	}
+
+	for _, f := range files {
+		var p = fmt.Sprintf("file://%v", filepath.Join(basePath, f.Name()))
+		if f.IsDir() {
+			result = append(result, reteriveFileList(p, match)...)
+		} else if match(f.Name()) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func reteriveGithubFileList(rawurl string, match func(string) bool) []string {
+	var b []byte = readContent(rawurl)
+
+	if b == nil {
+		return nil
+	}
+
+	var objects []map[string]interface{}
+	var result []string
+
+	if err := json.Unmarshal(b, &objects); err != nil {
+		var object map[string]interface{}
+		if err = json.Unmarshal(b, &object); err != nil {
+			return nil
+		}
+		objects = append(objects, object)
+	}
+
+	for _, obj := range objects {
+		var p = obj["path"].(string)
+
+		if obj["type"] == "file" {
+			if match(obj["name"].(string)) {
+				result = append(result, obj["download_url"].(string))
+			}
+		}
+
+		if obj["type"] == "dir" {
+			var nextContentsURL = apiContentsURL(rawurl, p)
+			result = append(result, reteriveFileList(nextContentsURL, match)...)
+		}
+	}
+
+	return result
+}
+
+func reteriveFileList(u string, match func(string) bool) []string {
+	if strings.HasPrefix(u, "https://raw.githubusercontent.com") {
+		return []string{u}
+	}
+	if strings.HasPrefix(u, "file://") {
+		return reteriveLocalFileList(u, match)
+	}
+	if strings.HasPrefix(u, "https://api.github.com/repos/") {
+		return reteriveGithubFileList(u, match)
+	}
+	return nil
+}
+
+func apiContentsURL(contentsURL string, newPath string) string {
+	var u, _ = url.Parse(contentsURL)
+	var segments = strings.Split(u.Path, string(filepath.Separator))
+
+	segments = append(segments[:5], newPath)
+	u.Path = strings.Join(segments, string(filepath.Separator))
+
+	return u.String()
+}

--- a/extensions/prefetch/images/images.go
+++ b/extensions/prefetch/images/images.go
@@ -171,6 +171,12 @@ func reteriveGithubFileList(rawurl string, match func(string) bool) []string {
 	}
 
 	for _, obj := range objects {
+		if _, ok := obj["path"]; !ok {
+			continue
+		}
+		if _, ok := obj["type"]; !ok {
+			continue
+		}
 		var p = obj["path"].(string)
 
 		if obj["type"] == "file" {

--- a/extensions/prefetch/images/images_test.go
+++ b/extensions/prefetch/images/images_test.go
@@ -1,0 +1,79 @@
+package images_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/networkservicemesh/integration-tests/extensions/prefetch/images"
+)
+
+var anyFileMatch = func(string) bool { return true }
+var yamlFileMatch = func(s string) bool { return strings.HasSuffix(s, ".yaml") }
+
+func Example_GithubRawContentsURL() {
+	const sampleURL = "https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.0.0/apps/nsc-kernel/nsc.yaml"
+
+	var list = images.ReteriveList([]string{sampleURL}, anyFileMatch)
+
+	fmt.Println(list.Images[0])
+	// Output:
+	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
+}
+
+func Example_GithubAPIFileURL() {
+	const sampleURL = "https://api.github.com/repos/networkservicemesh/deployments-k8s/contents/apps/nsc-kernel/nsc.yaml?ref=v1.0.0"
+
+	var list = images.ReteriveList([]string{sampleURL}, anyFileMatch)
+
+	fmt.Println(list.Images[0])
+	// Output:
+	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
+}
+
+func Example_GithubAPIDirectoryURL() {
+	const sampleURL = "https://api.github.com/repos/networkservicemesh/deployments-k8s/contents/apps/nsc-kernel?ref=v1.0.0"
+
+	var list = images.ReteriveList([]string{sampleURL}, anyFileMatch)
+
+	fmt.Println(list.Images[0])
+	// Output:
+	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
+}
+
+func Example_LocalDirectory1() {
+	var list = images.ReteriveList([]string{"file://samples"}, yamlFileMatch)
+	fmt.Println(list.Images[0])
+	fmt.Println(list.Images[1])
+	fmt.Println(list.Images[2])
+	// Output:
+	// alpine
+	// image1
+	// image2
+}
+
+func Example_LocalDirectory2() {
+	var list = images.ReteriveList([]string{"file://./"}, yamlFileMatch)
+	fmt.Println(list.Images[0])
+	fmt.Println(list.Images[1])
+	fmt.Println(list.Images[2])
+	// Output:
+	// alpine
+	// image1
+	// image2
+}
+
+func Example_LocalFile1() {
+	var list = images.ReteriveList([]string{"file://samples/alpine.yaml"}, yamlFileMatch)
+	fmt.Println(list.Images[0])
+	// Output:
+	// alpine
+}
+
+func Example_Prefetch() {
+	var list = images.ReteriveList([]string{"file://samples/prefetch.yaml"}, yamlFileMatch)
+	fmt.Println(list.Images[0])
+	fmt.Println(list.Images[1])
+	// Output:
+	// image1
+	// image2
+}

--- a/extensions/prefetch/images/images_test.go
+++ b/extensions/prefetch/images/images_test.go
@@ -26,70 +26,49 @@ import (
 var anyFileMatch = func(string) bool { return true }
 var yamlFileMatch = func(s string) bool { return strings.HasSuffix(s, ".yaml") }
 
-func Example_GithubRawContentsURL() {
-	const sampleURL = "https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.0.0/apps/nsc-kernel/nsc.yaml"
-
-	var list = images.ReteriveList([]string{sampleURL}, anyFileMatch)
-
-	fmt.Println(list.Images[0])
-	// Output:
-	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
-}
-
-func Example_GithubAPIFileURL() {
-	const sampleURL = "https://api.github.com/repos/networkservicemesh/deployments-k8s/contents/apps/nsc-kernel/nsc.yaml?ref=v1.0.0"
-
-	var list = images.ReteriveList([]string{sampleURL}, anyFileMatch)
-
-	fmt.Println(list.Images[0])
-	// Output:
-	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
-}
-
-func Example_GithubAPIDirectoryURL() {
-	const sampleURL = "https://api.github.com/repos/networkservicemesh/deployments-k8s/contents/apps/nsc-kernel?ref=v1.0.0"
-
-	var list = images.ReteriveList([]string{sampleURL}, anyFileMatch)
-
-	fmt.Println(list.Images[0])
-	// Output:
-	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
-}
-
-func Example_LocalDirectory1() {
-	var list = images.ReteriveList([]string{"file://samples"}, yamlFileMatch)
-	fmt.Println(list.Images[0])
-	fmt.Println(list.Images[1])
-	fmt.Println(list.Images[2])
-	// Output:
-	// alpine
-	// image1
-	// image2
-}
-
-func Example_LocalDirectory2() {
-	var list = images.ReteriveList([]string{"file://./"}, yamlFileMatch)
-	fmt.Println(list.Images[0])
-	fmt.Println(list.Images[1])
-	fmt.Println(list.Images[2])
-	// Output:
-	// alpine
-	// image1
-	// image2
-}
-
-func Example_LocalFile1() {
-	var list = images.ReteriveList([]string{"file://samples/alpine.yaml"}, yamlFileMatch)
-	fmt.Println(list.Images[0])
-	// Output:
-	// alpine
-}
-
-func Example_Prefetch() {
+func ExampleReteriveList() {
 	var list = images.ReteriveList([]string{"file://samples/prefetch.yaml"}, yamlFileMatch)
+
 	fmt.Println(list.Images[0])
 	fmt.Println(list.Images[1])
+
+	list = images.ReteriveList([]string{"https://raw.githubusercontent.com/networkservicemesh/deployments-k8s/v1.0.0/apps/nsc-kernel/nsc.yaml"}, anyFileMatch)
+
+	fmt.Println(list.Images[0])
+
+	list = images.ReteriveList([]string{"https://api.github.com/repos/networkservicemesh/deployments-k8s/contents/apps/nsc-kernel/nsc.yaml?ref=v1.0.0"}, anyFileMatch)
+
+	fmt.Println(list.Images[0])
+
+	list = images.ReteriveList([]string{"https://api.github.com/repos/networkservicemesh/deployments-k8s/contents/apps/nsc-kernel?ref=v1.0.0"}, anyFileMatch)
+
+	fmt.Println(list.Images[0])
+
+	list = images.ReteriveList([]string{"file://samples"}, yamlFileMatch)
+
+	fmt.Println(list.Images[0])
+	fmt.Println(list.Images[1])
+	fmt.Println(list.Images[2])
+
+	list = images.ReteriveList([]string{"file://./"}, yamlFileMatch)
+	fmt.Println(list.Images[0])
+	fmt.Println(list.Images[1])
+	fmt.Println(list.Images[2])
+
+	list = images.ReteriveList([]string{"file://samples/alpine.yaml"}, yamlFileMatch)
+	fmt.Println(list.Images[0])
+
 	// Output:
 	// image1
 	// image2
+	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
+	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
+	// ghcr.io/networkservicemesh/cmd-nsc:v1.0.0
+	// alpine
+	// image1
+	// image2
+	// alpine
+	// image1
+	// image2
+	// alpine
 }

--- a/extensions/prefetch/images/images_test.go
+++ b/extensions/prefetch/images/images_test.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package images_test
 
 import (

--- a/extensions/prefetch/images/samples/alpine.yaml
+++ b/extensions/prefetch/images/samples/alpine.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine
+  namespace: default
+spec:
+  containers:
+  - image: alpine
+    command:
+      - /bin/sh
+      - "-c"
+      - "sleep 60m"
+    imagePullPolicy: IfNotPresent
+    name: alpine
+  restartPolicy: Always

--- a/extensions/prefetch/images/samples/prefetch.yaml
+++ b/extensions/prefetch/images/samples/prefetch.yaml
@@ -1,0 +1,4 @@
+---
+images:
+  - image1
+  - image2

--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -55,7 +55,7 @@ func (s *Suite) initialize() {
 	require.NoError(s.T(), envconfig.Usage("prefetch", &config))
 	require.NoError(s.T(), envconfig.Process("prefetch", &config))
 
-	images := images.ReteriveList(s.SourcesURLs, func(s string) bool {
+	prefetchImages := images.ReteriveList(s.SourcesURLs, func(s string) bool {
 		return strings.HasSuffix(s, ".yaml") && !IsExcluded(s)
 	}).Images
 
@@ -66,10 +66,10 @@ func (s *Suite) initialize() {
 	r := s.Runner(tmpDir)
 
 	var daemonSets []string
-	for d := 0; d*config.ImagesPerDaemonset < len(images); d++ {
+	for d := 0; d*config.ImagesPerDaemonset < len(prefetchImages); d++ {
 		var containers string
-		for c := 0; c < config.ImagesPerDaemonset && d*config.ImagesPerDaemonset+c < len(images); c++ {
-			containers += container(uuid.NewString(), images[d*config.ImagesPerDaemonset+c])
+		for c := 0; c < config.ImagesPerDaemonset && d*config.ImagesPerDaemonset+c < len(prefetchImages); c++ {
+			containers += container(uuid.NewString(), prefetchImages[d*config.ImagesPerDaemonset+c])
 		}
 
 		r.Run(createDaemonSet(d, containers))

--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -59,6 +59,8 @@ func (s *Suite) initialize() {
 		return strings.HasSuffix(s, ".yaml") && !IsExcluded(s)
 	}).Images
 
+	prefetchImages = removeDuplicates(prefetchImages)
+
 	tmpDir := uuid.NewString()
 	require.NoError(s.T(), os.MkdirAll(tmpDir, 0750))
 	s.T().Cleanup(func() { _ = os.RemoveAll(tmpDir) })
@@ -93,4 +95,16 @@ func (s *Suite) initialize() {
 		}(daemonSet)
 	}
 	wg.Wait()
+}
+
+func removeDuplicates(source []string) []string {
+	var allKeys = make(map[string]bool)
+	var result []string
+	for _, item := range source {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			result = append(result, item)
+		}
+	}
+	return result
 }

--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -18,132 +18,79 @@
 package prefetch
 
 import (
-	"bufio"
+	"fmt"
 	"os"
-	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/gotestmd/pkg/suites/shell"
+	"github.com/networkservicemesh/integration-tests/extensions/prefetch/images"
 )
 
-const (
-	defaultDomain = "docker.io"
-	officialLib   = "library"
-	defaultTag    = ":latest"
-)
+// Config is env config to setup images prefetching.
+type Config struct {
+	ImagesPerDaemonset int    `default:"10" desc:"Number of images created per DaemonSet" split_words:"true"`
+	Timeout            string `default:"10m" desc:"Kubectl rollout status timeout for the DaemonSet" split_words:"true"`
+}
 
 // Suite creates `prefetch` daemonset which pulls all test images for all cluster nodes.
 type Suite struct {
 	shell.Suite
-	Dir string
+	SourcesURLs []string
 }
 
 var once sync.Once
 
 // SetupSuite prefetches docker images for each k8s node.
 func (s *Suite) SetupSuite() {
-	once.Do(func() {
-		testImages, err := s.findTestImages()
-		require.NoError(s.T(), err)
-
-		tmpDir := uuid.NewString()
-		require.NoError(s.T(), os.MkdirAll(tmpDir, 0750))
-
-		r := s.Runner(tmpDir)
-
-		r.Run(createNamespace)
-		r.Run(strings.ReplaceAll(createConfigMap, "{{.TestImages}}", strings.Join(testImages, " ")))
-		r.Run(createDaemonSet)
-		r.Run(createKustomization)
-
-		r.Run("kubectl apply -k .")
-		r.Run("kubectl -n prefetch wait --timeout=10m --for=condition=ready pod -l app=prefetch")
-
-		r.Run("kubectl delete ns prefetch")
-		_ = os.RemoveAll(tmpDir)
-	})
+	once.Do(s.initialize)
 }
 
-func (s *Suite) findTestImages() ([]string, error) {
-	imagePattern := regexp.MustCompile(".*image: (?P<image>.*)")
-	imageSubexpIndex := imagePattern.SubexpIndex("image")
+func (s *Suite) initialize() {
+	var config Config
+	require.NoError(s.T(), envconfig.Usage("prefetch", &config))
+	require.NoError(s.T(), envconfig.Process("prefetch", &config))
 
-	var testImages []string
-	walkFunc := func(path string, info os.FileInfo, err error) error {
-		if ok, skipErr := s.shouldSkipWithError(info, err); ok {
-			return skipErr
+	images := images.ReteriveList(s.SourcesURLs, func(s string) bool {
+		return strings.HasSuffix(s, ".yaml") && !IsExcluded(s)
+	}).Images
+
+	tmpDir := uuid.NewString()
+	require.NoError(s.T(), os.MkdirAll(tmpDir, 0750))
+	s.T().Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	r := s.Runner(tmpDir)
+
+	var daemonSets []string
+	for d := 0; d*config.ImagesPerDaemonset < len(images); d++ {
+		var containers string
+		for c := 0; c < config.ImagesPerDaemonset && d*config.ImagesPerDaemonset+c < len(images); c++ {
+			containers += container(uuid.NewString(), images[d*config.ImagesPerDaemonset+c])
 		}
-		// #nosec
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
 
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			if imagePattern.MatchString(scanner.Text()) {
-				image := imagePattern.FindAllStringSubmatch(scanner.Text(), -1)[0][imageSubexpIndex]
-				testImages = append(testImages, s.fullImageName(image))
-			}
-		}
+		r.Run(createDaemonSet(d, containers))
 
-		return nil
+		daemonSets = append(daemonSets, fmt.Sprintf("prefetch-%d", d))
 	}
 
-	if err := filepath.Walk(filepath.Join(s.Dir, "apps"), walkFunc); err != nil {
-		return nil, err
-	}
-	if err := filepath.Walk(filepath.Join(s.Dir, "examples", "spire"), walkFunc); err != nil {
-		return nil, err
-	}
+	r.Run("kubectl create ns prefetch")
+	s.T().Cleanup(func() { r.Run("kubectl delete ns prefetch") })
 
-	return testImages, nil
-}
+	var wg sync.WaitGroup
+	for _, daemonSet := range daemonSets {
+		wg.Add(1)
+		go func(daemonSet string) {
+			defer wg.Done()
 
-func (s *Suite) shouldSkipWithError(info os.FileInfo, err error) (bool, error) {
-	if err != nil {
-		return true, err
+			dr := s.Runner(tmpDir)
+			dr.Run(fmt.Sprintf("kubectl -n prefetch apply -f %s.yaml", daemonSet))
+			dr.Run(fmt.Sprintf("kubectl -n prefetch rollout status daemonset/%s --timeout=%s", daemonSet, config.Timeout))
+			dr.Run(fmt.Sprintf("kubectl -n prefetch delete -f %s.yaml", daemonSet))
+		}(daemonSet)
 	}
-
-	if info.IsDir() {
-		if IsExcluded(info.Name()) {
-			return true, filepath.SkipDir
-		}
-		return true, nil
-	}
-
-	if !strings.HasSuffix(info.Name(), ".yaml") {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (s *Suite) fullImageName(image string) string {
-	var domain, remainder string
-	i := strings.IndexRune(image, '/')
-	if i == -1 || (!strings.ContainsAny(image[:i], ".:")) {
-		domain, remainder = defaultDomain, image
-	} else {
-		domain, remainder = image[:i], image[i+1:]
-	}
-	if domain == defaultDomain && !strings.ContainsRune(remainder, '/') {
-		remainder = officialLib + "/" + remainder
-	}
-
-	switch len(strings.Split(remainder, ":")) {
-	case 2:
-		// nothing to do
-	case 1:
-		remainder += defaultTag
-	default:
-		return ""
-	}
-
-	return domain + "/" + remainder
+	wg.Wait()
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	k8s.io/api v0.20.5
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v0.20.5

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/api v0.20.5
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v0.20.5


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

Based on https://github.com/networkservicemesh/integration-tests/commit/51f1fd50c19dd3e645fac07af2aca361b05d6c65

## Motivation

1. Allows to prefetch work with GitHub api contents REST. It means we do not more need to checkout repository to find images.
2. Allows to prefetch load images from different sources.
2.1. Prefetch can load images from local sources directories and files.
2.2. Prefetch can load images from URLs in format "https://raw.githubusercontent.com/" 
2.3. Prefetch can load images from URLs in format "https://api.github.com/repos/ 
2.4. Prefetch can load images from file in yaml list format. For example:
```
---
images:
 - externalImage1
 - externalImage2
```
