### PR TITLE
qfix: Describe prefetch ns before cleanup

### DIFF
--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -82,7 +82,7 @@ func (s *Suite) initialize() {
 
 	r.Run("kubectl create ns prefetch")
 	s.T().Cleanup(func() {
-		r.Run("kubectl describe pods -n prefetch")
+		r.Run("kubectl delete ns prefetch")
 	})
 	var b, err = bash.New(bash.WithDir(tmpDir))
 	s.Require().NoError(err)

--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -91,6 +91,7 @@ func (s *Suite) initialize() {
 		mustLog(b.Run(fmt.Sprintf("kubectl -n prefetch apply -f %s.yaml", daemonSet)))
 		mustLog(b.Run(fmt.Sprintf("kubectl -n prefetch rollout status daemonset/%s --timeout=%s", daemonSet, config.Timeout)))
 		mustLog(b.Run("kubectl -n prefetch describe pods"))
+		mustLog(b.Run("kubectl get mutatingwebhookconfigurations"))
 		mustLog(b.Run(fmt.Sprintf("kubectl -n prefetch delete -f %s.yaml", daemonSet)))
 	}
 }


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

Sometimes aws/gke setup fail due to prefetch setup
```
SetupSuite.TestRunHealSuite/SetupSuite
Test execution failed SetupSuite
```

This patch should clarify the root cause.