### PR TITLE
[qfix]: Describe prefetch ns before cleanup

### DIFF
--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -80,7 +80,10 @@ func (s *Suite) initialize() {
 	}
 
 	r.Run("kubectl create ns prefetch")
-	s.T().Cleanup(func() { r.Run("kubectl delete ns prefetch") })
+	s.T().Cleanup(func() {
+		r.Run("kubectl describe pods -n prefetch")
+		r.Run("kubectl delete ns prefetch")
+	})
 
 	var wg sync.WaitGroup
 	for _, daemonSet := range daemonSets {


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

## Motivation

Sometimes aws/gke setup fail due to prefetch setup

```
SetupSuite.TestRunHealSuite/SetupSuite
Test execution failed SetupSuite
```

This patch should clarify the root cause.