### PR TITLE
[qfix] Fix prefetch absolute path

### DIFF
--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/extensions/prefetch/suite.go
+++ b/extensions/prefetch/suite.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,6 +20,7 @@ package prefetch
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -61,7 +62,9 @@ func (s *Suite) initialize() {
 
 	prefetchImages = removeDuplicates(prefetchImages)
 
-	tmpDir := uuid.NewString()
+	wd, err := os.Getwd()
+	require.NoError(s.T(), err)
+	tmpDir := filepath.Join(wd, uuid.NewString())
 	require.NoError(s.T(), os.MkdirAll(tmpDir, 0750))
 	s.T().Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 


### PR DESCRIPTION
### Description

`Prefetch` currently only works with a relative path. It is sufficient for the most cases, because we assume we are in the root folder. 
But it doesn't work, if we want to run tests from a subdirectory.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>