### PR TITLE
qfix: Release action is invalid in integration-tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,7 @@ jobs:
 
   create-release:
     name: Create release
-    needs: get-tag
     uses: networkservicemesh/.github/.github/workflows/release.yaml@main
-    with:
-      tag: ${{ needs.get-tag.outputs.tag }}
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
Fixes https://github.com/networkservicemesh/integration-tests/actions/runs/6353995559