### PR TITLE
Refactor: Don't use strings for excluding tests from the parallel execution

### DIFF
--- a/extensions/parallel/options.go
+++ b/extensions/parallel/options.go
@@ -17,15 +17,15 @@
 package parallel
 
 type parallelOptions struct {
-	excludedTests []string
+	syncTests []func()
 }
 
 // Option is an option pattern for parallel package
 type Option func(o *parallelOptions)
 
-// WithExcludedTests - set a list of tests to exclude from parallel execution
-func WithExcludedTests(tests []string) Option {
+// WithRunningTestsSynchronously - set a list of tests that should be run synchronously
+func WithRunningTestsSynchronously(tests ...func()) Option {
 	return func(o *parallelOptions) {
-		o.excludedTests = tests
+		o.syncTests = tests
 	}
 }

--- a/extensions/parallel/suite_test.go
+++ b/extensions/parallel/suite_test.go
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,9 +19,10 @@ package parallel_test
 import (
 	"testing"
 
-	"github.com/networkservicemesh/integration-tests/extensions/parallel"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
+
+	"github.com/networkservicemesh/integration-tests/extensions/parallel"
 )
 
 type negativeSuite struct {

--- a/extensions/parallel/suite_test.go
+++ b/extensions/parallel/suite_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 Pragmagic Inc. and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parallel_test
+
+import (
+	"testing"
+
+	"github.com/networkservicemesh/integration-tests/extensions/parallel"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
+)
+
+type negativeSuite struct {
+	suite.Suite
+}
+
+func (s *negativeSuite) TestParallel1() {}
+func (s *negativeSuite) TestParallel2() {}
+func (s *negativeSuite) TestParallel3() {}
+
+func (s *negativeSuite) TestSynchronously() {
+	s.Error(goleak.Find())
+}
+
+type positiveSuite struct {
+	suite.Suite
+}
+
+func (s *positiveSuite) TestParallel1() {}
+func (s *positiveSuite) TestParallel2() {}
+func (s *positiveSuite) TestParallel3() {}
+
+func (s *positiveSuite) TestSynchronously() {
+	s.NoError(goleak.Find())
+}
+
+func Test_OptionWithRunningTestsSynchronously_ShouldExcludeTestsFromParallelExecution(t *testing.T) {
+	var s1 = new(negativeSuite)
+	parallel.Run(t, s1)
+	var s2 = new(positiveSuite)
+	parallel.Run(t, s2, parallel.WithRunningTestsSynchronously(s2.TestSynchronously))
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.4
+	go.uber.org/goleak v1.1.10
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -40,10 +40,12 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.5.0 h1:60k92dhOjHxJkrqnwsfl8KuaHbn/5dl0lUPUklKo3qE=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Motivation 

1. Don't use strings for excluding tests from the parallel execution, because test names could be changed and we can get regression.
2. Added unit tests for coverage of functionality.
3. The original name 'WithExcludedTests' may confuse developers; it can be interpreted as 'don't run these tests'.

## Example

Old version of parallel package usage

```go
parallel.Run(t, mySuite, parallel.WithExcludedTests([]string{"a", "b", "c"})
```

New version of parallel package usage

```go
parallel.Run(t, mySuite, parallel.WithRunningTestsSynchronously(mySuite.TestA, mySuite.TestB, mySuite.TestC))
```

Relates to: https://github.com/networkservicemesh/integration-tests/issues/3510