### PR TITLE
Run release workflow only when CI passes on release branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
       - completed
     workflows:
       - "ci"
+    branches:
+      - release/*
 jobs:
   print-debug-info:
     name: Print debug info for Release workflow
@@ -16,7 +18,7 @@ jobs:
   get-tag:
     name: Get tag
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'release/') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       tag: ${{ steps.get-tag-step.outputs.tag }}
     steps:


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/.github/issues/67