### PR TITLE
Remove GKE from workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,6 @@ jobs:
     with:
       tag: ${{ needs.get-tag.outputs.tag }}
       dependent_repositories: |
-        ["integration-k8s-gke",
-         "integration-k8s-kind"]
+        ["integration-k8s-kind"]
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
This PR removes the integration-k8s-gke repository from the github workflows.

## Issue
https://github.com/networkservicemesh/deployments-k8s/issues/12681